### PR TITLE
Add fallback_on_mismatch option

### DIFF
--- a/lib/suture/surgeon/remediator.rb
+++ b/lib/suture/surgeon/remediator.rb
@@ -2,19 +2,44 @@ require "suture/util/scalpel"
 
 module Suture::Surgeon
   class Remediator
+    include Suture::Adapter::Log
+
     def initialize
       @scalpel = Suture::Util::Scalpel.new
     end
 
     def operate(plan)
       begin
-        @scalpel.cut(plan ,:new)
+        new_result = @scalpel.cut(plan, :new)
+        if plan.fallback_on_mismatch
+          old_result = @scalpel.cut(plan, :old)
+          fallback_on_mismatch(plan, old_result, new_result)
+        else
+          new_result
+        end
       rescue StandardError => actual_error
         if plan.expected_error_types.any? { |e| actual_error.is_a?(e) }
           raise actual_error
         else
           @scalpel.cut(plan, :old)
         end
+      end
+    end
+
+    def fallback_on_mismatch(plan, old_result, new_result)
+      if plan.comparator.call(old_result, new_result)
+        new_result
+      else
+        log_warn <<-MSG.gsub(/^ {10}/,'')
+          Seam #{plan.name.inspect} is set to :fallback_on_mismatch,
+          and they did not match. The new result was: ```
+            #{new_result.inspect}
+          ```
+          The old result was: ```
+            #{old_result.inspect}
+          ```
+        MSG
+        old_result
       end
     end
   end

--- a/lib/suture/value/plan.rb
+++ b/lib/suture/value/plan.rb
@@ -2,7 +2,8 @@ module Suture::Value
   class Plan
     attr_reader :name, :old, :new, :args, :after_new, :after_old, :on_new_error,
                 :on_old_error, :database_path, :record_calls, :comparator,
-                :call_both, :raise_on_result_mismatch, :fallback_on_error,
+                :call_both, :raise_on_result_mismatch,
+                :fallback_on_error, :fallback_on_mismatch,
                 :expected_error_types, :disable, :dup_args
 
     def initialize(attrs = {})
@@ -20,6 +21,7 @@ module Suture::Value
       @call_both = !!attrs[:call_both]
       @raise_on_result_mismatch = !!attrs[:raise_on_result_mismatch]
       @fallback_on_error = !!attrs[:fallback_on_error]
+      @fallback_on_mismatch = !!attrs[:fallback_on_mismatch]
       @expected_error_types = attrs[:expected_error_types] || []
       @disable = !!attrs[:disable]
       @dup_args = !!attrs[:dup_args]

--- a/test/suture/surgeon/remediator_test.rb
+++ b/test/suture/surgeon/remediator_test.rb
@@ -49,5 +49,45 @@ module Suture::Surgeon
       assert_raises(ZeroDivisionError) { @subject.operate(plan) }
       assert_equal false, old_called
     end
+
+    def test_call_old_if_fallback_on_mismatch
+      old_called = false
+      plan = Suture::BuildsPlan.new.build(:thing,
+        :old => lambda { old_called = true; :old_result },
+        :new => lambda { :new_result },
+        :args => [],
+        :fallback_on_error => true,
+        :fallback_on_mismatch => true
+      )
+      @subject.operate(plan)
+
+      assert_equal true, old_called
+    end
+
+    def test_return_result_when_match_if_fallback_on_mismatch
+      plan = Suture::BuildsPlan.new.build(:thing,
+        :old => lambda { :same_result },
+        :new => lambda { :same_result },
+        :args => [],
+        :fallback_on_error => true,
+        :fallback_on_mismatch => true
+      )
+      result = @subject.operate(plan)
+
+      assert_equal :same_result, result
+    end
+
+    def test_return_old_result_when_mismtach_if_fallback_on_mismatch
+      plan = Suture::BuildsPlan.new.build(:thing,
+        :old => lambda { :old_result },
+        :new => lambda { :new_result },
+        :args => [],
+        :fallback_on_error => true,
+        :fallback_on_mismatch => true
+      )
+      result = @subject.operate(plan)
+
+      assert_equal :old_result, result
+    end
   end
 end


### PR DESCRIPTION
Hi, I love this Gem's concept to enable refactoring legacy code with less fear.

`fallback_on_error` option looks good to try refactored code safely in production environment, and I think it would be safer if there is any option to use old option if the new and old result are mismatched.

Of course each call must be pure, but with such an option, we can test the new code in production without affecting the result, and then we could remove the suture with more confident, if a certain amount of time passed without any warnings.

What do you think about my idea?