### PR TITLE
Respect raise_on_result_mismatch with remediator

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,9 +449,9 @@ invoke the `new` code path. If `new` raises an error that isn't an
 `expected_error_type`, then Suture will invoke the `old` path with the same args
 in an attempt to recover a working state for the user. [Read more](#production)
 
-* _raise_on_result_mismatch_ - (Default: true) - when set to true, the
-`call_both` mode will merely log incidents of result mismatches, as opposed to
-raising `Suture::Error::ResultMismatch`.
+* _raise_on_result_mismatch_ - (Default: false) - when set to true, the
+`call_both` mode or `fallback_on_error` mode will raise
+`Suture::Error::ResultMismatch` if result mismatches.
 
 * _comparator_ - (Default: `Suture::Comparator.new`) - determines how return
 values from the Suture are compared when invoking `Suture.verify` or when

--- a/lib/suture/config.rb
+++ b/lib/suture/config.rb
@@ -8,7 +8,7 @@ module Suture
     :log_stdout => true,
     :log_io => nil,
     :log_file => nil,
-    :raise_on_result_mismatch => true
+    :raise_on_result_mismatch => false
   }
 
   def self.config(config = {})

--- a/test/suture/create/builds_plan_test.rb
+++ b/test/suture/create/builds_plan_test.rb
@@ -15,7 +15,7 @@ module Suture
       assert_kind_of Suture::Comparator, result.comparator
       assert_equal false, result.call_both
       assert_equal false, result.dup_args
-      assert_equal true, result.raise_on_result_mismatch
+      assert_equal false, result.raise_on_result_mismatch
       assert_equal [], result.expected_error_types
       assert_equal false, result.disable
     end
@@ -117,7 +117,7 @@ module Suture
       result = BuildsPlan.new.build(:something)
 
       assert_equal false, result.record_calls
-      assert_equal true, result.raise_on_result_mismatch
+      assert_equal false, result.raise_on_result_mismatch
     end
 
     def test_build_with_false_string_env_var

--- a/test/suture/surgeon/remediator_test.rb
+++ b/test/suture/surgeon/remediator_test.rb
@@ -49,5 +49,46 @@ module Suture::Surgeon
       assert_raises(ZeroDivisionError) { @subject.operate(plan) }
       assert_equal false, old_called
     end
+
+    def test_compare_old_result_when_raise_on_error_mismatch
+      old_called = false
+      plan = Suture::BuildsPlan.new.build(:thing,
+        :old => lambda { old_called = true; :same_result },
+        :new => lambda { :same_result },
+        :args => [],
+        :fallback_on_error => true,
+        :raise_on_result_mismatch => true
+      )
+      result = @subject.operate(plan)
+      assert_equal :same_result, result
+      assert_equal true, old_called
+    end
+
+    def test_use_old_result_when_result_mismatches
+      plan = Suture::BuildsPlan.new.build(:thing,
+        :old => lambda { :old_result },
+        :new => lambda { :new_result },
+        :args => [],
+        :fallback_on_error => true,
+        :raise_on_result_mismatch => true
+      )
+      result = @subject.operate(plan)
+      assert_equal :old_result, result
+    end
+
+    def test_call_old_just_once_when_result_mismatches
+      old_called_times = 0
+      plan = Suture::BuildsPlan.new.build(
+        :thing,
+        :old => lambda { old_called_times += 1; :old_result },
+        :new => lambda { :new_result },
+        :args => [],
+        :fallback_on_error => true,
+        :raise_on_result_mismatch => true
+      )
+      result = @subject.operate(plan)
+      assert_equal :old_result, result
+      assert_equal 1, old_called_times
+    end
   end
 end


### PR DESCRIPTION
As discussed at https://github.com/testdouble/suture/pull/60, I added a feature in Remediator that raises an error respecting raise_on_result_mismatch.