### PR TITLE
excludes example/ from codeclimate analysis

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -26,3 +26,4 @@ ratings:
 exclude_paths:
 - test/
 - safe/fixtures/
+- example/


### PR DESCRIPTION
example/ contains some intentionally bad code we probably don't want to
be analyzing