### PR TITLE
Return the old result when call_both mismatches and raise is disable

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,7 +392,9 @@ In general, most configuration options can be set in several places:
 to an expected ENV var named `SUTURE_RECORD_CALLS` and can be set from the
 command line like so: `SUTURE_RECORD_CALLS=true bundle exec rails server`, to
 tell Suture to record all your interactions with your seams without touching the
-source code.
+source code. (Note: this is really only appropriate if your codebase only has one
+Suture seam in progress at a time, since using a global env var configuration
+for one seam's sake will erroneously impact the other.)
 
 * Globally, via the top-level `Suture.config` method. Most variables can be set
 via this top-level configuration, like

--- a/README.md
+++ b/README.md
@@ -432,28 +432,35 @@ the `new` path at the exclusion of the `old` path (unless a mode flag like
 current working directory to the Sqlite3 database Suture uses to record and
 playback calls
 
-* _record_calls_ - (Default: false) - when set to true, the `old` path is called
+* _record_calls_ - (Default: `false`) - when set to true, the `old` path is called
 (regardless of whether `new` is set) and its arguments and result (be it a return
 value or an expected raised error) is recorded into the Suture database for the
 purpose of more coverage for calls to `Suture.verify`. [Read
 more](#3-record-the-current-behavior)
 
-* _call_both_ - (Default: false) - when set to true, the `new` path is invoked,
+* _call_both_ - (Default: `false`) - when set to true, the `new` path is invoked,
 then the `old` path is invoked, each with the seam's `args`. The return value
 from each is compared with the `comparator`, and if they are not equivalent, then
 a `Suture::Error::ResultMismatch` is raised. Intended after the `new` path is
 initially developed and to be run in pre-production environments. [Read
 more](#staging)
 
-* _fallback_on_error_ - (Default: false) - designed to be run in production after
+* _fallback_on_error_ - (Default: `false`) - designed to be run in production after
 the initial development of the new code path, when set to true, Suture will
 invoke the `new` code path. If `new` raises an error that isn't an
 `expected_error_type`, then Suture will invoke the `old` path with the same args
 in an attempt to recover a working state for the user. [Read more](#production)
 
-* _raise_on_result_mismatch_ - (Default: true) - when set to true, the
+* _raise_on_result_mismatch_ - (Default: `true`) - when set to true, the
 `call_both` mode will merely log incidents of result mismatches, as opposed to
-raising `Suture::Error::ResultMismatch`.
+raising `Suture::Error::ResultMismatch`
+
+* _return_old_on_result_mismatch_ - (Default: `false`) - when set to true, the
+`call_both` mode will return the result of the `old` code path instead of the
+`new` code path. This is useful when you want to log mismatches in production
+(i.e. when you're very confident it's safe and fast enough to use `call_both` in
+production), but want to fallback to the `old` path in the case of a mismatch
+to minimize disruption to your users
 
 * _comparator_ - (Default: `Suture::Comparator.new`) - determines how return
 values from the Suture are compared when invoking `Suture.verify` or when
@@ -474,13 +481,13 @@ certain cases, setting `:expected_error_types => [WidgetError]` will result in:
     errors raised by the `new` path to propogate, as opposed to logging &
     rescuing them before calling the `old` path as a fallback
 
-* _disable_ - (Default: false) - when enabled, Suture will attempt to revert to
+* _disable_ - (Default: `false`) - when enabled, Suture will attempt to revert to
 the original behavior of the `old` path and take no special action. Useful in
 cases where a bug is discovered in a deployed environment and you simply want
 to hit the brakes on any new code path experiments by setting
 `SUTURE_DISABLE=true` globally
 
-* _dup_args_ - (Default: false) - when enabled, Suture will call `dup` on each
+* _dup_args_ - (Default: `false`) - when enabled, Suture will call `dup` on each
 of the args passed to the `old` and/or `new` code paths. Useful when the code
 path(s) mutate the arguments in such a way as to prevent `call_both` or
 `fallback_on_error` from being effective
@@ -519,27 +526,27 @@ be either (or neither!)
 custom database path can be set for almost any invocation of Suture, and
 `Suture.verify is no exception`
 
-* _verify_only_ - (Default: nil) - when set to an ID, Suture.verify` will only
+* _verify_only_ - (Default: `nil`) - when set to an ID, Suture.verify` will only
 run against recorded calls for the matching ID. This option is meant to be used
 to focus work on resolving a single verification failure
 
-* _fail_fast_ - (Default: false) - `Suture.verify` will, by default, run against
+* _fail_fast_ - (Default: `false`) - `Suture.verify` will, by default, run against
 every single recording, aggregating and reporting on all errors (just like, say,
 RSpec or Minitest would). However, if the seam is slow to invoke or if you
 confidently expect all of the recordings to pass verification, `fail_fast` is an
 appropriate option to set.
 
-* _call_limit_ - (Default: nil) - when set to a number, Suture will only verify
+* _call_limit_ - (Default: `nil`) - when set to a number, Suture will only verify
 up to the set number of recorded calls. Because Suture randomizes the order of
 verifications by default, you can see this as setting Suture.verify to sample a
 random smattering of `call_limit` recordings as a smell test. Potentially useful
 when a seam is very slow
 
-* _time_limit_ - (Default: nil) - when set to a number (in seconds), Suture will
+* _time_limit_ - (Default: `nil`) - when set to a number (in seconds), Suture will
 stop running verifications against recordings once `time_limit` seconds has
 elapsed. Useful when a seam is very slow to invoke
 
-* _error_message_limit_ - (Default: nil) - when set to a number, Suture will only
+* _error_message_limit_ - (Default: `nil`) - when set to a number, Suture will only
 print up to `error_message_limit` failure messages. That way, if you currently
 have hundreds of verifications failing, your console isn't overwhelmed by them on
 each run of `Suture.verify`

--- a/lib/suture/create/validates_plan.rb
+++ b/lib/suture/create/validates_plan.rb
@@ -53,6 +53,11 @@ module Suture
         if plan.fallback_on_error && !plan.new.respond_to?(:call)
           ":fallback_on_error is set but :new is either not set or is not callable. This mode is designed for after the :new code path has been developed and run in production-like environments, where :old is only kept around as a fallback to retry in the event that :new raises an unexpected error. Either specify a :new code path or disable :fallback_on_error."
         end
+      },
+      lambda { |plan|
+        if !plan.raise_on_result_mismatch && !plan.call_both
+          ":raise_on_result_mismatch was disabled but :call_both is not enabled. This option only applies to the :call_both mode, and will have no impact when set for other modes"
+        end
       }
     ]
 

--- a/lib/suture/create/validates_plan.rb
+++ b/lib/suture/create/validates_plan.rb
@@ -26,37 +26,81 @@ module Suture
     CONFLICTS = [
       lambda { |plan|
         if plan.record_calls && !plan.database_path
-          ":record_calls is enabled, but :database_path is nil, so Suture doesn't know where to record calls to the seam."
+          <<-MSG.gsub(/^ {12}/,'')
+            :record_calls is enabled, but :database_path is nil, so Suture
+              doesn't know where to record calls to the seam.
+          MSG
         end
       },
       lambda { |plan|
         if plan.record_calls && plan.call_both
-          ":record_calls & :call_both are both enabled and conflict with one another. :record_calls will only invoke the old code path (intended for characterization of the old code path and initial development of the new code path), whereas :call_both will invoke the new path and the old to compare their results after development of the new code path is initially complete (typically in a pre-production environment to validate the behavior of the new code path is consistent with the old). If you're still actively developing the new code path and need more recordings to feed Suture.verify, disable :call_both; otherwise, it's likely time to turn off :record_calls on this seam."
+          <<-MSG.gsub(/^ {12}/,'')
+            :record_calls & :call_both are both enabled and conflict with one
+              another. :record_calls will only invoke the old code path (intended
+              for characterization of the old code path and initial development
+              of the new code path), whereas :call_both will invoke the new path
+              and the old to compare their results after development of the new
+              code path is initially complete (typically in a pre-production
+              environment to validate the behavior of the new code path is
+              consistent with the old). If you're still actively developing the
+              new code path and need more recordings to feed Suture.verify,
+              disable :call_both; otherwise, it's likely time to turn off
+              :record_calls on this seam.
+          MSG
         end
       },
       lambda { |plan|
         if plan.record_calls && plan.fallback_on_error
-          ":record_calls & :fallback_on_error are both enabled and conflict with one another. :record_calls will only invoke the old code path (intended for characterization of the old code path and initial development of the new code path), whereas :fallback_on_error will call the new code path unless an error is raised, in which case it will fall back on the old code path."
+          <<-MSG.gsub(/^ {12}/,'')
+            :record_calls & :fallback_on_error are both enabled and conflict with
+              one another. :record_calls will only invoke the old code path
+              (intended for characterization of the old code path and initial
+              development of the new code path), whereas :fallback_on_error will
+              call the new code path unless an error is raised, in which case it
+              will fall back on the old code path.
+          MSG
         end
       },
       lambda { |plan|
         if plan.call_both && plan.fallback_on_error
-          ":call_both & :fallback_on_error are both enabled and conflict with one another. :call_both is designed for pre-production environments and will call both the old and new code paths to compare their results, whereas :fallback_on_error is designed for production environments where it is safe to call the old code path in the event that the new code path fails unexpectedly"
+          <<-MSG.gsub(/^ {12}/,'')
+            :call_both & :fallback_on_error are both enabled and conflict with
+              one another. :call_both is designed for pre-production environments
+              and will call both the old and new code paths to compare their
+              results, whereas :fallback_on_error is designed for production
+              environments where it is safe to call the old code path in the
+              event that the new code path fails unexpectedly
+          MSG
         end
       },
       lambda { |plan|
         if plan.call_both && !plan.new.respond_to?(:call)
-          ":call_both is set but :new is either not set or is not callable. In order to call both code paths, both :old and :new must be set and callable."
+          <<-MSG.gsub(/^ {12}/,'')
+            :call_both is set but :new is either not set or is not callable. In
+              order to call both code paths, both :old and :new must be set and
+              callable
+          MSG
         end
       },
       lambda { |plan|
         if plan.fallback_on_error && !plan.new.respond_to?(:call)
-          ":fallback_on_error is set but :new is either not set or is not callable. This mode is designed for after the :new code path has been developed and run in production-like environments, where :old is only kept around as a fallback to retry in the event that :new raises an unexpected error. Either specify a :new code path or disable :fallback_on_error."
+          <<-MSG.gsub(/^ {12}/,'')
+            :fallback_on_error is set but :new is either not set or is not
+              callable. This mode is designed for after the :new code path has
+              been developed and run in production-like environments, where :old
+              is only kept around as a fallback to retry in the event that
+              :new raises an unexpected error. Either specify a :new code path or
+              disable :fallback_on_error.
+          MSG
         end
       },
       lambda { |plan|
         if !plan.raise_on_result_mismatch && !plan.call_both
-          ":raise_on_result_mismatch was disabled but :call_both is not enabled. This option only applies to the :call_both mode, and will have no impact when set for other modes"
+          <<-MSG.gsub(/^ {12}/,'')
+            :raise_on_result_mismatch was disabled but :call_both is not enabled.
+              This option only applies to the :call_both mode, and will have no
+              impact when set for other modes
+          MSG
         end
       }
     ]

--- a/lib/suture/surgeon/auditor.rb
+++ b/lib/suture/surgeon/auditor.rb
@@ -10,20 +10,35 @@ module Suture::Surgeon
       new_result = scalpel.cut(plan, :new)
       old_result = scalpel.cut(plan, :old)
       if !plan.comparator.call(old_result, new_result)
-        log_warn <<-MSG.gsub(/^ {10}/,'')
-          Seam #{plan.name.inspect} is set to :call_both the :new and :old code
-          paths, but they did not match. The new result was: ```
-            #{new_result.inspect}
-          ```
-          The old result was: ```
-            #{old_result.inspect}
-          ```
-        MSG
-        if plan.raise_on_result_mismatch
-          raise Suture::Error::ResultMismatch.new(plan, new_result, old_result)
-        end
+        handle_mismatch(plan, old_result, new_result)
+      else
+        new_result
       end
-      new_result
+    end
+
+    private
+
+    def handle_mismatch(plan, old_result, new_result)
+      log_warning(plan, old_result, new_result)
+      if plan.raise_on_result_mismatch
+        raise Suture::Error::ResultMismatch.new(plan, new_result, old_result)
+      elsif plan.return_old_on_result_mismatch
+        old_result
+      else
+        new_result
+      end
+    end
+
+    def log_warning(plan, old_result, new_result)
+      log_warn <<-MSG.gsub(/^ {8}/,'')
+        Seam #{plan.name.inspect} is set to :call_both the :new and :old code
+        paths, but they did not match. The new result was: ```
+          #{new_result.inspect}
+        ```
+        The old result was: ```
+          #{old_result.inspect}
+        ```
+      MSG
     end
   end
 end

--- a/lib/suture/value/plan.rb
+++ b/lib/suture/value/plan.rb
@@ -2,7 +2,8 @@ module Suture::Value
   class Plan
     attr_reader :name, :old, :new, :args, :after_new, :after_old, :on_new_error,
                 :on_old_error, :database_path, :record_calls, :comparator,
-                :call_both, :raise_on_result_mismatch, :fallback_on_error,
+                :call_both, :raise_on_result_mismatch,
+                :return_old_on_result_mismatch, :fallback_on_error,
                 :expected_error_types, :disable, :dup_args
 
     def initialize(attrs = {})
@@ -19,6 +20,7 @@ module Suture::Value
       @comparator = attrs[:comparator]
       @call_both = !!attrs[:call_both]
       @raise_on_result_mismatch = !!attrs[:raise_on_result_mismatch]
+      @return_old_on_result_mismatch = !!attrs[:return_old_on_result_mismatch]
       @fallback_on_error = !!attrs[:fallback_on_error]
       @expected_error_types = attrs[:expected_error_types] || []
       @disable = !!attrs[:disable]

--- a/test/support/assertions.rb
+++ b/test/support/assertions.rb
@@ -12,12 +12,13 @@ module Support
 
     ##
     # Fails unless +matcher+ <tt>=~</tt> +obj+ (with whitespace normalized a bit)
+    # Flips expected & actual so it's easier to use heredocs
 
-    def assert_spacey_match matcher, obj, msg = nil
+    def assert_spacey_match obj, matcher, msg = nil
       msg = message(msg) { "Expected #{mu_pp matcher} to match #{mu_pp obj} (with relaxed whitespace)" }
       assert_respond_to matcher, :"=~"
-      matcher = Regexp.new Regexp.escape matcher.gsub(/\s+/, ' ') if String === matcher
-      assert matcher =~ obj.gsub(/\s+/, ' '), msg
+      matcher = Regexp.new(Regexp.escape(matcher.gsub(/\s+/, ''))) if String === matcher
+      assert(matcher =~ obj.gsub(/\s+/, ''), msg)
     end
   end
 end

--- a/test/suture/create/builds_plan_test.rb
+++ b/test/suture/create/builds_plan_test.rb
@@ -16,6 +16,7 @@ module Suture
       assert_equal false, result.call_both
       assert_equal false, result.dup_args
       assert_equal true, result.raise_on_result_mismatch
+      assert_equal false, result.return_old_on_result_mismatch
       assert_equal [], result.expected_error_types
       assert_equal false, result.disable
     end
@@ -48,6 +49,7 @@ module Suture
         :comparator => some_comparator,
         :database_path => "blah.db",
         :raise_on_result_mismatch => false,
+        :return_old_on_result_mismatch => true,
         :after_new => some_after_new,
         :after_old => some_after_old,
         :on_new_error => some_on_new_error,
@@ -65,6 +67,7 @@ module Suture
       assert_equal some_comparator, result.comparator
       assert_equal "blah.db", result.database_path
       assert_equal false, result.raise_on_result_mismatch
+      assert_equal true, result.return_old_on_result_mismatch
       assert_equal some_after_new, result.after_new
       assert_equal some_after_old, result.after_old
       assert_equal some_on_new_error, result.on_new_error
@@ -83,6 +86,7 @@ module Suture
       ENV['SUTURE_COMPARATOR'] = 'e'
       ENV['SUTURE_DATABASE_PATH'] = 'd'
       ENV['SUTURE_RAISE_ON_RESULT_MISMATCH'] = 'false'
+      ENV['SUTURE_RETURN_OLD_ON_RESULT_MISMATCH'] = 'true'
       ENV['SUTURE_AFTER_OLD'] = 'f'
       ENV['SUTURE_AFTER_NEW'] = 'g'
       ENV['SUTURE_ON_NEW_ERROR'] = 'i'
@@ -102,6 +106,7 @@ module Suture
       assert_equal nil, result.args
       assert_equal Suture::DEFAULT_OPTIONS[:comparator], result.comparator
       assert_equal false, result.raise_on_result_mismatch
+      assert_equal true, result.return_old_on_result_mismatch
       assert_equal nil, result.after_old
       assert_equal nil, result.after_new
       assert_equal nil, result.on_new_error

--- a/test/suture/create/validates_plan_test.rb
+++ b/test/suture/create/validates_plan_test.rb
@@ -10,7 +10,8 @@ module Suture
     end
 
     def test_valid_plan
-      plan = Value::Plan.new(:name => :pants, :old => lambda {}, :args => [])
+      plan = Value::Plan.new(:name => :pants, :old => lambda {}, :args => [],
+                             :raise_on_result_mismatch => true)
 
       result = @subject.validate(plan)
 
@@ -196,5 +197,17 @@ module Suture
       MSG
     end
 
+    def test_raise_when_raise_mismatch_is_set_for_non_call_both
+      plan = Value::Plan.new(:name => :pants, :old => lambda {}, :args => [],
+                             :raise_on_result_mismatch => false)
+
+      error = assert_raises(Error::InvalidPlan) { @subject.validate(plan) }
+
+      assert_spacey_match error.message, <<-MSG
+        * :raise_on_result_mismatch was disabled but :call_both is not enabled. This
+          option only applies to the :call_both mode, and will have no impact
+          when set for other modes
+      MSG
+    end
   end
 end

--- a/test/suture/create/validates_plan_test.rb
+++ b/test/suture/create/validates_plan_test.rb
@@ -24,9 +24,11 @@ module Suture
 
       error = assert_raises(Error::InvalidPlan) { @subject.validate(plan) }
 
-      assert_spacey_match "options passed to `Suture.create` were invalid", error.message
-      assert_spacey_match "The following options are required:", error.message
-      assert_spacey_match "* :name - in order to identify recorded calls", error.message
+      assert_spacey_match error.message, <<-MSG
+        options passed to `Suture.create` were invalid.
+          The following options are required:
+            * :name - in order to identify recorded calls
+      MSG
     end
 
     def test_raise_when_no_code_path
@@ -34,7 +36,9 @@ module Suture
 
       error = assert_raises(Error::InvalidPlan) { @subject.validate(plan) }
 
-      assert_spacey_match "* :old - in order to call the legacy code path (must respond to `:call`)", error.message
+      assert_spacey_match error.message, <<-MSG
+        * :old - in order to call the legacy code path (must respond to `:call`)
+      MSG
     end
 
     def test_raise_when_args_are_not_set
@@ -42,7 +46,12 @@ module Suture
 
       error = assert_raises(Error::InvalidPlan) { @subject.validate(plan) }
 
-      assert_spacey_match "in order to differentiate recorded calls (if the code you're changing doesn't take arguments, you can set :args to `[]` but should probably consider creating a seam inside of it which can--consult the README for more advice)", error.message
+      assert_spacey_match error.message, <<-MSG
+        in order to differentiate recorded calls (if the code you're changing
+        doesn't take arguments, you can set :args to `[]` but should probably
+        consider creating a seam inside of it which can--consult the README for
+        more advice)
+      MSG
     end
 
     def test_raise_with_multiple_missing_required_params
@@ -50,9 +59,9 @@ module Suture
 
       error = assert_raises(Error::InvalidPlan) { @subject.validate(plan) }
 
-      assert_spacey_match "* :name", error.message
-      assert_spacey_match "* :old", error.message
-      assert_spacey_match "* :args", error.message
+      assert_spacey_match error.message, "* :name"
+      assert_spacey_match error.message, "* :old"
+      assert_spacey_match error.message, "* :args"
     end
 
     # 2. Arguments are invalid
@@ -62,8 +71,10 @@ module Suture
 
       error = assert_raises(Error::InvalidPlan) { @subject.validate(plan) }
 
-      assert_spacey_match "The following options were invalid:", error.message
-      assert_spacey_match "* :name - must be less than 256 characters", error.message
+      assert_spacey_match error.message, <<-MSG
+        The following options were invalid:
+          * :name - must be less than 256 characters
+      MSG
     end
 
     def test_raise_when_old_is_not_callable
@@ -71,7 +82,10 @@ module Suture
 
       error = assert_raises(Error::InvalidPlan) { @subject.validate(plan) }
 
-      assert_spacey_match "* :old - must respond to `call` (e.g. `dog.method(:bark)` or `->(*args){ dog.bark(*args) }`)", error.message
+      assert_spacey_match error.message, <<-MSG
+        * :old - must respond to `call` (e.g. `dog.method(:bark)` or
+          `->(*args){ dog.bark(*args) }`)
+      MSG
     end
 
     def test_raise_when_new_is_defined_and_not_callable
@@ -79,7 +93,10 @@ module Suture
 
       error = assert_raises(Error::InvalidPlan) { @subject.validate(plan) }
 
-      assert_spacey_match "* :new - must respond to `call` (e.g. `dog.method(:bark)` or `->(*args){ dog.bark(*args) }`)", error.message
+      assert_spacey_match error.message, <<-MSG
+        * :new - must respond to `call` (e.g. `dog.method(:bark)` or
+          `->(*args){ dog.bark(*args) }`)
+      MSG
     end
 
     def test_raise_when_comparator_is_defined_and_not_callable
@@ -88,7 +105,10 @@ module Suture
 
       error = assert_raises(Error::InvalidPlan) { @subject.validate(plan) }
 
-      assert_spacey_match "* :comparator - must respond to `call` (e.g. `MyComparator.new` or `->(recorded, actual) { recorded == actual }`)", error.message
+      assert_spacey_match error.message, <<-MSG
+        * :comparator - must respond to `call` (e.g. `MyComparator.new` or
+          `->(recorded, actual) { recorded == actual }`)
+      MSG
     end
 
     # 3. Invalid combinations
@@ -99,8 +119,11 @@ module Suture
 
       error = assert_raises(Error::InvalidPlan) { @subject.validate(plan) }
 
-      assert_spacey_match "Suture isn't sure how to best handle the combination of options passed", error.message
-      assert_spacey_match "* :record_calls is enabled, but :database_path is nil, so Suture doesn't know where to record calls to the seam.", error.message
+      assert_spacey_match error.message, <<-MSG
+        Suture isn't sure how to best handle the combination of options passed:
+          * :record_calls is enabled, but :database_path is nil, so Suture
+            doesn't know where to record calls to the seam.
+      MSG
     end
 
     def test_raise_when_record_calls_and_call_both_are_both_set
@@ -110,7 +133,18 @@ module Suture
 
       error = assert_raises(Error::InvalidPlan) { @subject.validate(plan) }
 
-      assert_spacey_match "* :record_calls & :call_both are both enabled and conflict with one another. :record_calls will only invoke the old code path (intended for characterization of the old code path and initial development of the new code path), whereas :call_both will invoke the new path and the old to compare their results after development of the new code path is initially complete (typically in a pre-production environment to validate the behavior of the new code path is consistent with the old). If you're still actively developing the new code path and need more recordings to feed Suture.verify, disable :call_both; otherwise, it's likely time to turn off :record_calls on this seam.", error.message
+      assert_spacey_match error.message, <<-MSG
+        * :record_calls & :call_both are both enabled and conflict with one
+          another. :record_calls will only invoke the old code path (intended
+          for characterization of the old code path and initial development of
+          the new code path), whereas :call_both will invoke the new path and
+          the old to compare their results after development of the new code
+          path is initially complete (typically in a pre-production environment
+          to validate the behavior of the new code path is consistent with the
+          old). If you're still actively developing the new code path and need
+          more recordings to feed Suture.verify, disable :call_both; otherwise,
+          it's likely time to turn off :record_calls on this seam.
+      MSG
     end
 
     def test_raise_when_record_calls_and_fallback_on_error_are_both_set
@@ -120,7 +154,14 @@ module Suture
 
       error = assert_raises(Error::InvalidPlan) { @subject.validate(plan) }
 
-      assert_spacey_match "* :record_calls & :fallback_on_error are both enabled and conflict with one another. :record_calls will only invoke the old code path (intended for characterization of the old code path and initial development of the new code path), whereas :fallback_on_error will call the new code path unless an error is raised, in which case it will fall back on the old code path.", error.message
+      assert_spacey_match error.message, <<-MSG
+        * :record_calls & :fallback_on_error are both enabled and conflict with
+          one another. :record_calls will only invoke the old code path
+          (intended for characterization of the old code path and initial
+          development of the new code path), whereas :fallback_on_error will
+          call the new code path unless an error is raised, in which case it
+          will fall back on the old code path.
+      MSG
     end
 
     def test_raise_when_call_both_and_fallback_on_error_are_both_set
@@ -129,16 +170,30 @@ module Suture
 
       error = assert_raises(Error::InvalidPlan) { @subject.validate(plan) }
 
-      assert_spacey_match "* :call_both & :fallback_on_error are both enabled and conflict with one another. :call_both is designed for pre-production environments and will call both the old and new code paths to compare their results, whereas :fallback_on_error is designed for production environments where it is safe to call the old code path in the event that the new code path fails unexpectedly", error.message
+      assert_spacey_match error.message, <<-MSG
+        * :call_both & :fallback_on_error are both enabled and conflict with
+          one another. :call_both is designed for pre-production environments
+          and will call both the old and new code paths to compare their
+          results, whereas :fallback_on_error is designed for production
+          environments where it is safe to call the old code path in the
+          event that the new code path fails unexpectedly
+      MSG
     end
 
-    def test_raise_when_call_both_does_not_have_both_paths
+    def test_raise_when_fallback_on_error_does_not_have_both_paths
       plan = Value::Plan.new(:name => :pants, :old => lambda {}, :args => [],
                              :fallback_on_error => true)
 
       error = assert_raises(Error::InvalidPlan) { @subject.validate(plan) }
 
-      assert_spacey_match "* :fallback_on_error is set but :new is either not set or is not callable. This mode is designed for after the :new code path has been developed and run in production-like environments, where :old is only kept around as a fallback to retry in the event that :new raises an unexpected error. Either specify a :new code path or disable :fallback_on_error.", error.message
+      assert_spacey_match error.message, <<-MSG
+        * :fallback_on_error is set but :new is either not set or is not
+          callable. This mode is designed for after the :new code path has been
+          developed and run in production-like environments, where :old is only
+          kept around as a fallback to retry in the event that :new raises an
+          unexpected error. Either specify a :new code path or disable
+          :fallback_on_error.
+      MSG
     end
 
   end

--- a/test/suture/surgeon/auditor_test.rb
+++ b/test/suture/surgeon/auditor_test.rb
@@ -92,6 +92,20 @@ module Suture::Surgeon
       assert_equal :shrugface, result
     end
 
+    def test_returns_old_when_toggled_and_raise_disabled
+      plan = Suture::BuildsPlan.new.build(:face_swap,
+        :old => lambda { |type| :trollface },
+        :new => lambda { |type| :shrugface },
+        :args => [:face],
+        :raise_on_result_mismatch => false,
+        :return_old_on_result_mismatch => true
+      )
+
+      result = @subject.operate(plan)
+
+      assert_equal :trollface, result
+    end
+
     def test_passes_when_comparator_bails_them_out
       plan = Suture::BuildsPlan.new.build(:less_than_10,
         :old => lambda { 8 },

--- a/test/suture/util/scalpel_test.rb
+++ b/test/suture/util/scalpel_test.rb
@@ -88,7 +88,7 @@ module Suture::Util
       )
 
       assert_raises(ZeroDivisionError) { @subject.cut(plan, :old) }
-      expected_message = <<-MSG.gsub(/^ {8}/,'')
+      assert_spacey_match log_io.tap(&:rewind).read, <<-MSG.gsub(/^ {8}/,'')
         Suture invoked the :my_seam seam's :old code path with args: ```
           [1, 2]
         ```
@@ -96,7 +96,6 @@ module Suture::Util
           divided by 0
         ```
       MSG
-      assert_spacey_match expected_message, log_io.tap(&:rewind).read
     end
 
     def test_does_not_log_errors_when_expected


### PR DESCRIPTION
- [x] add an `:return_old_on_result_mismatch` flag
- [x] when `:call_both` is enabled and `:raise_on_result_mismatch` is disabled, return the correct result

When using `:call_both` and having disabled `:raise_on_mismatch`, then Suture ought to allow the user to specify that it should return the old value rather than the new value.

Previously, Suture would return the new result in all such cases, which is probably the least surprising behavior folks would expect, especially in a staging environment, but if using call_both in an environment where you'd rather recover a bit more gracefully (e.g. you want a warning that a mismatch occurred but you don't want to start returning the wrong value), then you should have an option to return the old value.

See #60 and #61 for prior discussion