### PR TITLE
Fix CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 sudo: false
 rvm:
-  - 1.8.7
   - 1.9
   - 2.0
   - 2.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rvm:
   - 2.2
   - 2.3.3
 before_install:
-  - gem install bundler
+  - gem install bundler -v 1.17.3
   - bundle --version
   - cd example/rails_app && ./script/setup.sh && cd ../..
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ rvm:
   - 2.3.3
 before_install:
   - gem install bundler
+  - bundle --version
   - cd example/rails_app && ./script/setup.sh && cd ../..
 after_success:
   - bundle exec codeclimate-test-reporter

--- a/suture.gemspec
+++ b/suture.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "backports"
   spec.add_dependency "bar-of-progress", ">= 0.1.3"
 
-  spec.add_development_dependency "bundler", "~> 1.12"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "pry", "~> 0.9.12.6"
   spec.add_development_dependency "minitest", "~> 5.9"


### PR DESCRIPTION
Most notably, I dropped Ruby 1.8.7 from Travis because:
* it only seems to be available on an old distro—Trusty
* even when using it on an old distro, [it fails to install bundler](https://travis-ci.org/github/testdouble/suture/jobs/767757235) because it appears to be incapable of verifying rubygems.org's cert (presumably an OpenSSL issue?)

@searls I'm wondering if you have any thoughts/feelings about dropping Ruby 1.8.7.

Other than that, most of what I did here was the usual bundler version shenanigans. 😬 